### PR TITLE
Different column layout to fix double scrollbars

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,9 @@
+:root {
+  --editor-height: calc(100vh - 350px);
+  --editor-height-2: calc(100vh - 385px);
+  --output-height: 10vh;
+}
+
 body {
   margin: 0;
   font-family: "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
@@ -78,8 +84,12 @@ h1, h2, h3, h4, h5, h6 {
   margin-right: 0.5em;
 }
 
+#editor {
+  max-height: var(--editor-height);
+}
+
 .CodeMirror {
-  height: calc(100% - 72px);
+  max-height: var(--editor-height-2);
   margin-top: 72px;
 }
 
@@ -152,6 +162,10 @@ h1, h2, h3, h4, h5, h6 {
 
 .content {
   padding: 1.5em;
+}
+
+.content2 {
+  margin: 1.5em
 }
 
 @media only screen and (min-width: 1300px) {
@@ -287,3 +301,9 @@ button .buttonhint {
     transform: rotate(0deg); }
   to {
     transform: rotate(359deg); } }
+
+#output {
+  height: var(--output-height);
+  overflow-y: auto;
+  flex-grow: 1;
+}

--- a/frontend.nim
+++ b/frontend.nim
@@ -49,6 +49,7 @@ createAliases("tdiv"):
   "big editor"
   "small column"
   "optionsbar"
+  "content2"
 
 type
   CodeMirror = distinct Element
@@ -261,27 +262,26 @@ proc createDom(data: RouterData): VNode =
                 for version in knownVersions:
                   option:
                     text version
-        smallColumn:
-          bar:
-            if not awaitingShare:
-              otherButton(onclick = shareIx):
-                text "Share to ix"
-            else:
-              otherButton(class = "is-loading"):
-                text "Share to ix"
-            otherButton(onclick = switchOutput):
-              text "Showing: " & $output
-            if not runningCode:
-              mainButton(onclick = runCode):
-                text "Run!"
-                span(class = "buttonhint"):
-                  text "(ctrl-enter)"
-            else:
-              mainButton(class = "is-loading"):
-                text "Run!"
-          growContent:
-            pre(class = "monospace"):
-              verbatim outputText[output]
+        bar:
+          if not awaitingShare:
+            otherButton(onclick = shareIx):
+              text "Share to ix"
+          else:
+            otherButton(class = "is-loading"):
+              text "Share to ix"
+          otherButton(onclick = switchOutput):
+            text "Showing: " & $output
+          if not runningCode:
+            mainButton(onclick = runCode):
+              text "Run!"
+              span(class = "buttonhint"):
+                text "(ctrl-enter)"
+          else:
+            mainButton(class = "is-loading"):
+              text "Run!"
+        content2(id = "output"):
+          pre(class = "monospace"):
+            verbatim outputText[output]      
 
 setRenderer createDom, "ROOT", postRender
 setForeignNodeId "tour"


### PR DESCRIPTION
Removed the bottom items from `smallColumn` and moved them so they're in the same margin as the editor.

Gave the editor a fixed height that is calculated and stored in 2 variables. 

One is for #editor the other is for CodeMirror which is a bit smaller.

Gave the output a height, and made it flex-grow:1 so it fills to the bottom.

Removed the padding from the output's <pre> and turned it into a margin.