### PR TITLE
Cleaner look

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,6 +1,6 @@
 :root {
   --editor-height: calc(100vh - 350px);
-  --editor-height-2: calc(100vh - 385px);
+  --editor-height-2: calc(100vh - 360px);
   --output-height: 10vh;
 }
 
@@ -29,6 +29,8 @@ h1, h2, h3, h4, h5, h6 {
 
 .headerbar {
   height: 2.4em;
+  display: flex;
+  flex-direction: row;
 }
 
 .headerbar > a {
@@ -61,12 +63,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .optionsbar {
-  position: absolute;
-  top: 2.4em;
-  right: 0px;
   height: 48px;
   margin-right: 1em;
   font-size: 16px;
+  align-self: center;
+  padding: 20px;
 }
 
 .optionsbar input[type=number] {
@@ -124,7 +125,7 @@ h1, h2, h3, h4, h5, h6 {
 
   .CodeMirror {
     height: calc(100% - 24px);
-    margin-top: 24px;
+    margin-top: 10px;
   }
 }
 
@@ -306,4 +307,9 @@ button .buttonhint {
   height: var(--output-height);
   overflow-y: auto;
   flex-grow: 1;
+}
+
+#githublink {
+  align-self: center;
+  margin-left: auto;
 }

--- a/frontend.nim
+++ b/frontend.nim
@@ -230,7 +230,24 @@ proc createDom(data: RouterData): VNode =
       a(href = "https://play.nim-lang.org"):
         img(src = "/assets/logo.svg")
         span: text "Playground"
-      a(href = "https://github.com/PMunch/nim-playground-frontend"):
+      optionsBar:
+        span:
+          text "Font size: "
+          input(`type` = "number", id = "fontsize", value = "13", `min` = "8", `max` = "50", step = "1", required = "required", onchange = changeFontSize)
+        span:
+          text " Compilation target: "
+          select(id = "compilationtarget"):
+            option:
+              text "C"
+            option:
+              text "C++"
+        span:
+          text " Nim version: "
+          select(id = "nimversion"):
+            for version in knownVersions:
+              option:
+                text version
+      a(id = "githublink", href = "https://github.com/PMunch/nim-playground-frontend"):
         span: text "Code on GitHub"
     mainarea:
       if showingTour:
@@ -244,24 +261,7 @@ proc createDom(data: RouterData): VNode =
             mainButton(onclick = () => (currentSection = min(currentSection + 1, totalSections - 1))):
               text "Next"
       baseColumn:
-        bigEditor(id = "editor", class = "monospace"):
-          optionsBar:
-            span:
-              text "Font size: "
-              input(`type` = "number", id = "fontsize", value = "13", `min` = "8", `max` = "50", step = "1", required = "required", onchange = changeFontSize)
-            span:
-              text " Compilation target: "
-              select(id = "compilationtarget"):
-                option:
-                  text "C"
-                option:
-                  text "C++"
-            span:
-              text " Nim version: "
-              select(id = "nimversion"):
-                for version in knownVersions:
-                  option:
-                    text version
+        bigEditor(id = "editor", class = "monospace")
         bar:
           if not awaitingShare:
             otherButton(onclick = shareIx):


### PR DESCRIPTION
I thought the interface needed a bit of polish, for instance some things didn't have proper spacing around the elements like the github link.

This gives elements better spacing while giving the editor more area after moving some of the buttons to the header.

This is how it currently is:

![playold](https://user-images.githubusercontent.com/206498/131491134-04ebe8b1-fda0-4e22-ae54-10a7bd955699.jpg)

This is how I modified it:

![nimclean](https://user-images.githubusercontent.com/206498/131491158-74057711-b967-4a4e-ad94-86093b276c55.jpg)
